### PR TITLE
Make an example more idiomatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1644,8 +1644,8 @@ Recursion works in Rust too, so this sort of function does work:
      
 ```rust
 fn print_vec(mut input: Vec<i32>) {
-    if !input.is_empty() { // note the !
-        println!("{}", input.pop().unwrap());
+    if let Some(last) = input.pop() {
+        println!("{}", last);
         print_vec(input); // calling the same function
     } else {
         println!("All done!");


### PR DESCRIPTION
`.unwrap()` is not a good sign (and optimizes poorly, though I didn't check this example specifically). `if let` is more appropriate here (though `match` will do too).